### PR TITLE
Inconsistency between instructions and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ In the lab that follows, practice using closures to construct functions that hav
 
 Create the following functions:
 
-  + `produceDrivingRange()` - Returns a function that then calculates whether a given trip is within range.  For example, `produceDrivingRange(10)` returns a function that will return `false` if the trip is over 10 blocks distance and `true` if the distance is within range.  So `produceDrivingRange` returns a function that we can then use to calculate if a trip is too large for a driver.  We recommend referencing the `test/indexTest.js` for more details.
+  + `produceDrivingRange()` - Returns a function that then calculates whether a given trip is within range.  For example, `produceDrivingRange(10)` returns a function that will take two strings as arguments and returns a message stating whether the trip is in range. If `foo = produceDrivingRange(10)`, then `foo('12th', '15th')` would return `"within range by 7"` and `foo('12th', '30th')` would return `"8 blocks out of range"`. We recommend referencing the `test/indexTest.js` for more details.
   + `produceTipCalculator()` - Returns a function that then calculates a tip.  For example, `produceTipCalculator(.10)` returns a function that calculates ten percent tip on a fare.  `produceTipCalculator(.20)` returns a function that calculates twenty percent tip on a fare.
   + `createDriver` is a function that returns a Driver class.  The class has reference to a driverId that is incremented each time a new driver is created.  The rest of the code base does not have access to driverId.  
 


### PR DESCRIPTION
Changing the instructions for produceDrivingRange() to reflect what the tests check for. Previously, the instructions asked students to produce a function returning a boolean while the tests expected a string